### PR TITLE
tee_client_api: Change type of shared memory id parameter

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -190,7 +190,7 @@ static TEEC_Result teec_pre_process_tmpref(TEEC_Context *ctx,
 		if (ctx->memref_null) {
 			/* Null pointer, indicate no shared memory attached */
 			MEMREF_SHM_ID(param) = TEE_MEMREF_NULL;
-			shm->id = -1;
+			shm->id = TEEC_SHM_INVALID_ID;
 		} else {
 			res = TEEC_AllocateSharedMemory(ctx, shm);
 			if (res != TEEC_SUCCESS)
@@ -800,7 +800,7 @@ TEEC_Result TEEC_AllocateSharedMemory(TEEC_Context *ctx, TEEC_SharedMemory *shm)
 		shm->buffer = teec_shm_alloc(ctx->dev, s, 0);
 
 		if (!shm->buffer) {
-			shm->id = -1;
+			shm->id = TEEC_SHM_INVALID_ID;
 			return TEEC_ERROR_OUT_OF_MEMORY;
 		}
 		shm->registered_shm = NULL;
@@ -814,7 +814,7 @@ TEEC_Result TEEC_AllocateSharedMemory(TEEC_Context *ctx, TEEC_SharedMemory *shm)
 
 void TEEC_ReleaseSharedMemory(TEEC_SharedMemory *shm)
 {
-	if (!shm || shm->id == -1 || !shm->dev)
+	if (!shm || shm->id == TEEC_SHM_INVALID_ID || !shm->dev)
 		return;
 
 	if (shm->shadow_buffer) {
@@ -833,7 +833,7 @@ void TEEC_ReleaseSharedMemory(TEEC_SharedMemory *shm)
 		tee_shm_unregister(shm->dev, shm->registered_shm);
 	}
 
-	shm->id = -1;
+	shm->id = TEEC_SHM_INVALID_ID;
 	shm->shadow_buffer = NULL;
 	shm->buffer = NULL;
 	shm->registered_shm = NULL;

--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -274,6 +274,11 @@ typedef struct {
 } TEEC_UUID;
 
 /**
+ * Invalid shared memory identifier for TEEC_SharedMemory id field.
+ */
+#define TEEC_SHM_INVALID_ID (~0)
+
+/**
  * struct TEEC_SharedMemory - Memory to transfer data between a client
  * application and trusted code.
  *
@@ -297,7 +302,7 @@ typedef struct {
 	/*
 	 * Implementation-Defined
 	 */
-	int id;
+	uint64_t id;
 	size_t alloced_size;
 	void *shadow_buffer;
 	struct tee_shm *registered_shm;


### PR DESCRIPTION
Switch SharedMemory id parameter from int to uint64_t. In original optee-client library for Linux int is enough because fd is stored there. But in Zephyr id (which is shm_ref for OP-TEE) is a pointer to shm structure so generic `int` type which is 32-bit in Zephyr is not enough to store structure pointer and may lead to passing different highbits of shm_ref on SHM_REGISTER and INVOKE_COMMAND calls.