### PR TITLE
tee_supplicant: Start supplicant thread on initialization error

### DIFF
--- a/tee_supplicant/src/tee_supplicant.c
+++ b/tee_supplicant/src/tee_supplicant.c
@@ -385,7 +385,7 @@ static int tee_supp_init(const struct device *dev)
 	sys_dlist_init(&shm_list);
 
 	if (tee_get_version(tee_dev, &info)) {
-		LOG_ERR("Unable to allocate thread argument");
+		LOG_ERR("Unable to retrieve tee capabilities");
 		return -EINVAL;
 	}
 	if (!(info.gen_caps & TEE_GEN_CAP_REG_MEM)) {


### PR DESCRIPTION
Supplicant thread isn/t started if secrure storage can't be prepared. It leads to hang OPTEE calls. This patch starts supplicant thread in any case but doesn't execute file system command if secure storage wasn't properly prepared.