### PR TITLE
tee_supplicant: use correct parameters for supplicant init

### DIFF
--- a/tee_supplicant/src/tee_supplicant.c
+++ b/tee_supplicant/src/tee_supplicant.c
@@ -415,6 +415,6 @@ SYS_INIT(tee_supp_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #else
 int TEE_SupplicantInit(void)
 {
-	return tee_supp_init(NULL);
+	return tee_supp_init();
 }
 #endif


### PR DESCRIPTION
After migration to Zephyr v3.6.0 initcall signature was changed and related changes were merged to tee_supplicant. But one of supplicant init calls was not changed and it produces errors during builds with supplicant autoinit disabled.